### PR TITLE
kleene lists are now in the standard library

### DIFF
--- a/src/Data/List/Kleene/Internal.agda
+++ b/src/Data/List/Kleene/Internal.agda
@@ -1,6 +1,6 @@
 {-# OPTIONS --without-K --safe #-}
 
-module Data.List.Kleene where
+module Data.List.Kleene.Internal where
 
 -- This module provides a different definition of lists based on the kleene
 -- star and plus.

--- a/src/Polynomial/Expr/Normalising.agda
+++ b/src/Polynomial/Expr/Normalising.agda
@@ -74,7 +74,7 @@ normalise (O x) = go x
   go (⊝ x) | C x₁ = C (- x₁)
   go (⊝ x) | O x₁ = O (⊝ x₁)
 
-open import Data.List.Kleene
+open import Data.List.Kleene.Internal
 open import Data.Product
 open import Data.Nat
 

--- a/src/Polynomial/NormalForm/Definition.agda
+++ b/src/Polynomial/NormalForm/Definition.agda
@@ -21,7 +21,7 @@ open import Data.Empty       using (⊥)
 open import Data.Unit        using (⊤)
 open import Data.Nat         using (ℕ; suc; zero)
 open import Data.Bool        using (T)
-open import Data.List.Kleene public
+open import Data.List.Kleene.Internal public
 
 infixl 6 _Δ_
 record PowInd {c} (C : Set c) : Set c where


### PR DESCRIPTION
Kleene lists are now in the standard library: https://agda.github.io/agda-stdlib/Data.List.Kleene.html

Agda doesn't know which file to use so I had to rename the file. 

You may want to switch to the standard library's kleene list. If I get time I'll submit a PR that does that.

PS: Love the library I'm using it in my senior thesis